### PR TITLE
Solve the copy pnglibconf.h.prebuilt

### DIFF
--- a/third_party/libpng/libpng.gyp
+++ b/third_party/libpng/libpng.gyp
@@ -25,14 +25,9 @@
           'actions': [
             {
               'action_name': 'copy_libpngconf_prebuilt',
-              'inputs' : [],
-              'outputs': [''],
-              'action': [
-                'cp',
-                '-f',
-                '<(DEPTH)/third_party/libpng/src/scripts/pnglibconf.h.prebuilt',
-                '<(DEPTH)/third_party/libpng/src/pnglibconf.h',
-              ],
+              'inputs' : ['<(DEPTH)/third_party/libpng/src/scripts/pnglibconf.h.prebuilt'],
+              'outputs': ['<(DEPTH)/third_party/libpng/src/pnglibconf.h'],
+              'action': ['cp', '-f', '<@(_inputs)','<@(_outputs)'],
             },
           ],
           'msvs_guid': 'C564F145-9172-42C3-BFCB-6014CA97DBCD',


### PR DESCRIPTION
This change solve the issue that don´t copy libpng/src/scripts/pnglibconf.h.prebuilt to libpng/src/pnglibconf.h.
It changes in the generated libpng/libpng.target.mk the command cd third_party/libpng to mkdir -p ../../third_party/libpng/src. I don´t know why, but the file get copyed